### PR TITLE
feat #10: Timer -> ScheduledExecutorService, 입력값 받아서 크롤링(Scanner)

### DIFF
--- a/src/main/java/krx/crawling/utils/KrxCrawler.java
+++ b/src/main/java/krx/crawling/utils/KrxCrawler.java
@@ -84,16 +84,16 @@ public final class KrxCrawler {
     private <T> List<T> crawlStocks(String date, String url, StockDtoBuilder<T> builder, int fieldCount)
             throws InterruptedException {
 
-        if (!isValidDate(date))
-            throw new IllegalArgumentException("Invalid date format: " + date);
+        if (!isValidDate(date)) throw new IllegalArgumentException("Invalid date format: " + date);
 
         List<T> result = new ArrayList<>();
+
         logger.info("Open a window for crawling. url: " + url);
         driver.get(url);
-
         logger.info(driver.getTitle());
 
         boolean isPossible = setDate(date);
+
         if (!isPossible) throw new IllegalStateException("Weekend or holiday (" + date + ")");
 
         logger.info("Finish setting date. Selected date is " + date);


### PR DESCRIPTION
### 변경 사항
- Timer -> ScheduledExecutorService
  - liveJob(Scanner)은 foreground, batchJob은 background로 스레드를 나누고 싶어졌다.
  - Timer는 모든 예약된 작업을 단일 스레드에서 수행하는 반면, ScheduledExecutorService는 스레드 풀을 관리할 수 있다.
- liveJob 생성
  - Scanner를 이용해 input(year, month, day, numOfDays)을 받아 해당 날짜의 데이터를 크롤링 한다.
  - input value 관련 예외 처리
    - NumberFormatException: 숫자가 아닌 값이 들어왔을 때
    - IllegalStateException): 적절한 연도 값이 아닐 때(curYear  ±4)
    - DateTimeException: 적절한 월 또일 일 값이 아닐 때 ex) month: 13
